### PR TITLE
Add you2me filter plugin

### DIFF
--- a/filter/you2me/classes/text_filter.php
+++ b/filter/you2me/classes/text_filter.php
@@ -1,0 +1,33 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace filter_you2me;
+
+/**
+ * Simple filter that replaces occurrences of 'you' with 'me'.
+ *
+ * @package    filter_you2me
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class text_filter extends \core_filters\text_filter {
+    #[\Override]
+    public function filter($text, array $options = []) {
+        if ($text === '' || is_numeric($text)) {
+            return $text;
+        }
+        return preg_replace('/\byou\b/i', 'me', $text);
+    }
+}

--- a/filter/you2me/filter.php
+++ b/filter/you2me/filter.php
@@ -1,0 +1,27 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * File only retained to prevent fatal errors in code that tries to require/include this.
+ *
+ * @todo MDL-82708 delete this file as part of Moodle 6.0 development.
+ * @deprecated This file is no longer required in Moodle 4.5+.
+ * @package filter_you2me
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+defined('MOODLE_INTERNAL') || die();
+
+debugging('This file is no longer required in Moodle 4.5+. Please do not include/require it.', DEBUG_DEVELOPER);

--- a/filter/you2me/lang/en/filter_you2me.php
+++ b/filter/you2me/lang/en/filter_you2me.php
@@ -1,0 +1,3 @@
+<?php
+$string['filtername'] = 'You to me filter';
+$string['privacy:metadata'] = 'The You to me filter plugin does not store any personal data.';

--- a/filter/you2me/tests/text_filter_test.php
+++ b/filter/you2me/tests/text_filter_test.php
@@ -1,0 +1,22 @@
+<?php
+namespace filter_you2me;
+
+use core\context\system as context_system;
+
+final class text_filter_test extends \advanced_testcase {
+    public function test_basic_replacement(): void {
+        $this->resetAfterTest();
+
+        $filter = new text_filter(context_system::instance(), []);
+        $result = $filter->filter('you and YOU', ['originalformat' => FORMAT_HTML]);
+        $this->assertSame('me and me', $result);
+    }
+
+    public function test_partial_words_are_not_changed(): void {
+        $this->resetAfterTest();
+
+        $filter = new text_filter(context_system::instance(), []);
+        $result = $filter->filter('young you youtube yours', ['originalformat' => FORMAT_HTML]);
+        $this->assertSame('young me youtube yours', $result);
+    }
+}

--- a/filter/you2me/version.php
+++ b/filter/you2me/version.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version information
+ *
+ * @package    filter_you2me
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->version   = 2025041400;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->requires  = 2025040800;        // Requires this Moodle version.
+$plugin->component = 'filter_you2me'; // Full name of the plugin (used for diagnostics)


### PR DESCRIPTION
## Summary
- add a simple `you2me` filter plugin
- include PHPUnit tests for whole-word replacement logic

## Testing
- `php admin/phpunit/cli/init.php` *(fails: command not found)*
- `vendor/bin/phpunit filter/you2me/tests/text_filter_test.php` *(fails: no such file or directory)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68514a8b50908331b6320428e81e5b1e